### PR TITLE
Updated Querying for Tasks & Return of CreateGroup

### DIFF
--- a/packages/express-backend/controllers/groupController.js
+++ b/packages/express-backend/controllers/groupController.js
@@ -33,10 +33,11 @@ export async function createGroup(req, res) {
     try {
         const token = req.headers.authorization;
         const user_id = getUserId(token);
-        const group_name = req.body.group_name
+        const group_name = req.body.group_name;
+        const group_description = req.body.group_description;
 
-        const group_id = await groupService.createGroup(group_name, user_id);
-        return res.status(201).send(group_id);
+        const group_id = await groupService.createGroup(group_name, group_description, user_id);
+        return res.status(201).send({group_id: group_id});
     } catch (error) {
         console.log(error);
         return res.status(500).send({error: error.message});

--- a/packages/express-backend/controllers/taskController.js
+++ b/packages/express-backend/controllers/taskController.js
@@ -16,8 +16,9 @@ export async function getAllUserTasks(req, res) {
         const token = req.headers.authorization;
         const user_id = getUserId(token);
         const status = typeof req.query.status === 'string' ? req.query.status : null;
+        const order = typeof req.query.order === 'string' ? req.query.order : null;
 
-        const tasks = await taskService.getAllUserTasks(user_id, status);
+        const tasks = await taskService.getAllUserTasks(user_id, status, order);
         return res.status(200).send(tasks);
     } catch (error) {
         console.log(error);
@@ -27,7 +28,8 @@ export async function getAllUserTasks(req, res) {
 
 /**
  * Fetches all tasks belonging to a group
- * Optional query parameter of status
+ * 
+ * Optional query parameter of status and deadline (asc or desc)
  * @param {*} req 
  * @param {*} res 
  * @returns A list of the group's tasks
@@ -38,12 +40,13 @@ export async function getGroupTasks(req, res) {
         const user_id = getUserId(token);
         const group_id = req.params.id;
         const status = typeof req.query.status === 'string' ? req.query.status : null;
+        const order = typeof req.query.order === 'string' ? req.query.order : null;
 
         if (!(await verifyUserInGroup(group_id, user_id))) {
             return res.status(401).send("User not in group");
         }
 
-        const tasks = await taskService.getGroupTasks(group_id, status)
+        const tasks = await taskService.getGroupTasks(group_id, status, order);
         return res.status(200).send(tasks);
     } catch (error) {
         console.log(error);

--- a/packages/express-backend/services/groupService.js
+++ b/packages/express-backend/services/groupService.js
@@ -8,12 +8,13 @@ import db from "../utils/db.js";
  * @param {*} ownerId 
  * @returns The groupId
  */
-export async function createGroup(groupName, ownerId) {
+export async function createGroup(groupName, groupDescription, ownerId) {
     // Inserting new group and returning group_id
     const { data, error } = await db
         .from("groups")
         .insert({
             groupName : groupName,
+            description : groupDescription,
             groupOwner : ownerId
         })
         .select();

--- a/packages/express-backend/services/taskService.js
+++ b/packages/express-backend/services/taskService.js
@@ -7,7 +7,7 @@ import db from "../utils/db.js";
  * @param {*} user_id 
  * @returns A list of tasks
  */
-export async function getAllUserTasks(user_id, status = null) {
+export async function getAllUserTasks(user_id, status = null, order = null) {
     let query = db
         .from("tasks")
         .select(`
@@ -25,6 +25,10 @@ export async function getAllUserTasks(user_id, status = null) {
     if (typeof status === 'string' && status.length > 0) {
         query.eq("status", status);
     }
+    if (typeof order === 'string' && order.length > 0) {
+        query = query.order("deadline", {ascending: order === 'asc'});
+    }
+
 
     const { data, error } = await query;
     
@@ -48,7 +52,7 @@ export async function getAllUserTasks(user_id, status = null) {
  * @param {*} group_id 
  * @returns A list of tasks
  */
-export async function getGroupTasks(group_id, status = null) {
+export async function getGroupTasks(group_id, status = null, order = null) {
     let query = db
         .from("tasks")
         .select(`
@@ -65,6 +69,9 @@ export async function getGroupTasks(group_id, status = null) {
 
     if (typeof status === 'string' && status.length > 0) {
         query = query.eq("status", status);
+    }
+    if (typeof order === 'string' && order.length > 0) {
+        query = query.order("deadline", {ascending: order === 'asc'});
     }
 
     const { data, error } = await query;


### PR DESCRIPTION
## Tasks
Updated the following:
- `GET /groups/:id/tasks` and `GET /tasks`
     - Can now query both `status` and `order`
     - `status` can be either `COMPLETED`, `IN_PROGRESS`, `NOT_COMPLETED`
     - `order` can be either `asc` or `desc`
 - `POST /groups`
     - Now has additional body parameter of `group_description` to match the frontend page
     - Changed format of the return to json of `group_id : int`
